### PR TITLE
feat(schueler): Schülerverwaltung mit DSGVO-Pseudonymisierung

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'screens/home_screen.dart';
 import 'screens/login_screen.dart';
 import 'screens/klassen_screen.dart';
 import 'screens/faecher_screen.dart';
+import 'screens/schueler_screen.dart';
 import 'core/theme/rbs_theme.dart';
 
 /// Converts a [Stream] into a [Listenable] for use with GoRouter's refreshListenable.
@@ -77,6 +78,10 @@ final _router = GoRouter(
     GoRoute(
       path: '/faecher',
       builder: (context, state) => const FaecherScreen(),
+    ),
+    GoRoute(
+      path: '/schueler',
+      builder: (context, state) => const SchuelerScreen(),
     ),
   ],
 );

--- a/lib/models/student.dart
+++ b/lib/models/student.dart
@@ -1,54 +1,93 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:math';
 
+/// Schüler-Model mit DSGVO-konformer Pseudonymisierung
+/// 
+/// Speichert nur pseudonymisierte Daten in Firestore.
+/// Das Mapping (Pseudonym → echter Name) wird lokal exportiert.
 class Student {
   final String id;
-  final String firstName;
-  final String lastName;
-  final String? className;
+  final String pseudonym; // z.B. "S001", "S002"
+  final String? firstName; // Optional, nur lokal
+  final String? lastName;  // Optional, nur lokal  
+  final String klasseId;   // Referenz zur Klasse
   final DateTime createdAt;
 
   Student({
     required this.id,
-    required this.firstName,
-    required this.lastName,
-    this.className,
+    required this.pseudonym,
+    this.firstName,
+    this.lastName,
+    required this.klasseId,
     required this.createdAt,
   });
 
-  String get fullName => '$firstName $lastName';
+  /// Anzeigename: Pseudonym oder echter Name falls vorhanden
+  String get displayName {
+    if (firstName != null && lastName != null) {
+      return '$firstName $lastName';
+    }
+    return pseudonym;
+  }
+
+  /// Generiert ein neues Pseudonym (S001, S002, ...)
+  static String generatePseudonym(int index) {
+    return 'S${(index + 1).toString().padLeft(3, '0')}';
+  }
+
+  /// Generiert ein zufälliges Pseudonym
+  static String generateRandomPseudonym() {
+    final random = Random();
+    final number = random.nextInt(9999) + 1;
+    return 'S${number.toString().padLeft(4, '0')}';
+  }
 
   factory Student.fromFirestore(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
     return Student(
       id: doc.id,
-      firstName: data['firstName'] as String,
-      lastName: data['lastName'] as String,
-      className: data['className'] as String?,
-      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      pseudonym: data['pseudonym'] as String? ?? doc.id.substring(0, 6),
+      firstName: data['firstName'] as String?,
+      lastName: data['lastName'] as String?,
+      klasseId: data['klasseId'] as String? ?? '',
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
     );
   }
 
+  /// Nur pseudonymisierte Daten werden in Firestore gespeichert
   Map<String, dynamic> toFirestore() {
     return {
-      'firstName': firstName,
-      'lastName': lastName,
-      'className': className,
+      'pseudonym': pseudonym,
+      'klasseId': klasseId,
       'createdAt': Timestamp.fromDate(createdAt),
+      // firstName und lastName werden NICHT gespeichert (DSGVO)
+    };
+  }
+
+  /// Für lokales Mapping-Export (CSV)
+  Map<String, dynamic> toLocalMapping() {
+    return {
+      'pseudonym': pseudonym,
+      'firstName': firstName ?? '',
+      'lastName': lastName ?? '',
+      'klasseId': klasseId,
     };
   }
 
   Student copyWith({
     String? id,
+    String? pseudonym,
     String? firstName,
     String? lastName,
-    String? className,
+    String? klasseId,
     DateTime? createdAt,
   }) {
     return Student(
       id: id ?? this.id,
+      pseudonym: pseudonym ?? this.pseudonym,
       firstName: firstName ?? this.firstName,
       lastName: lastName ?? this.lastName,
-      className: className ?? this.className,
+      klasseId: klasseId ?? this.klasseId,
       createdAt: createdAt ?? this.createdAt,
     );
   }

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -62,6 +62,15 @@ final studentProvider = FutureProvider.family<Student, String>((ref, id) async {
   return firestoreService.getStudent(id);
 });
 
+// Students by Klasse
+final studentsByKlasseProvider = StreamProvider.family<List<Student>, String>((
+  ref,
+  klasseId,
+) {
+  final firestoreService = ref.watch(firestoreServiceProvider);
+  return firestoreService.getStudentsByKlasse(klasseId);
+});
+
 // ============ SUBJECT PROVIDERS ============
 
 // All subjects stream

--- a/lib/screens/klassen_screen.dart
+++ b/lib/screens/klassen_screen.dart
@@ -597,12 +597,15 @@ Future<void> _importNow() async {
       );
 
       final students = preview.students
+          .asMap()
+          .entries
           .map(
-            (s) => Student(
+            (entry) => Student(
               id: '',
-              firstName: s.firstName,
-              lastName: s.lastName,
-              className: klasse.name,
+              pseudonym: Student.generatePseudonym(entry.key),
+              firstName: entry.value.firstName,
+              lastName: entry.value.lastName,
+              klasseId: '', // Will be set by importKlasseMitSchuelern
               createdAt: DateTime.now(),
             ),
           )

--- a/lib/screens/schueler_screen.dart
+++ b/lib/screens/schueler_screen.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../core/theme/rbs_theme.dart';
+import '../core/widgets/rbs_components.dart';
+import '../models/student.dart';
+import '../models/beruf.dart';
+import '../providers/app_providers.dart';
+import '../widgets/rbs_drawer.dart';
+
+/// Schülerverwaltung Screen
+/// - Listet alle Schüler mit Filter nach Klasse
+/// - DSGVO-konforme Pseudonymisierung
+/// - CRUD Funktionalität
+class SchuelerScreen extends ConsumerStatefulWidget {
+  const SchuelerScreen({super.key});
+
+  @override
+  ConsumerState<SchuelerScreen> createState() => _SchuelerScreenState();
+}
+
+class _SchuelerScreenState extends ConsumerState<SchuelerScreen> {
+  String? _selectedKlasseId;
+
+  @override
+  Widget build(BuildContext context) {
+    final klassenAsync = ref.watch(klassenProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Schülerverwaltung'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: _selectedKlasseId != null
+                ? () => _showStudentDialog()
+                : null,
+            tooltip: 'Neuer Schüler',
+          ),
+        ],
+      ),
+      drawer: const RBSDrawer(),
+      body: Column(
+        children: [
+          // Klassen-Filter
+          Container(
+            padding: const EdgeInsets.all(RBSSpacing.md),
+            color: RBSColors.paper,
+            child: klassenAsync.when(
+              data: (klassen) => Wrap(
+                spacing: RBSSpacing.sm,
+                runSpacing: RBSSpacing.sm,
+                children: klassen.map((klasse) {
+                  return RBSFilterChip(
+                    label: klasse.name,
+                    selected: _selectedKlasseId == klasse.id,
+                    color: _getBerufColor(klasse.beruf),
+                    onSelected: (selected) {
+                      setState(() {
+                        _selectedKlasseId = selected ? klasse.id : null;
+                      });
+                    },
+                  );
+                }).toList(),
+              ),
+              loading: () => const Center(
+                child: CircularProgressIndicator(),
+              ),
+              error: (e, _) => Text('Fehler: $e'),
+            ),
+          ),
+
+          // Schüler-Liste
+          Expanded(
+            child: _selectedKlasseId == null
+                ? _buildEmptyState('Wähle eine Klasse aus')
+                : _buildStudentList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStudentList() {
+    final studentsAsync = ref.watch(
+      studentsByKlasseProvider(_selectedKlasseId!),
+    );
+
+    return studentsAsync.when(
+      data: (students) {
+        if (students.isEmpty) {
+          return _buildEmptyState('Keine Schüler in dieser Klasse');
+        }
+
+        return ListView.builder(
+          padding: const EdgeInsets.all(RBSSpacing.md),
+          itemCount: students.length,
+          itemBuilder: (context, index) {
+            final student = students[index];
+            return _buildStudentCard(student);
+          },
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('Fehler: $e')),
+    );
+  }
+
+  Widget _buildStudentCard(Student student) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: RBSSpacing.sm),
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: RBSColors.dynamicRed,
+          child: Text(
+            student.pseudonym.substring(0, 2),
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        title: Text(
+          student.displayName,
+          style: RBSTypography.bodyMedium.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        subtitle: Text(
+          'Pseudonym: ${student.pseudonym}',
+          style: RBSTypography.bodySmall,
+        ),
+        trailing: PopupMenuButton<String>(
+          onSelected: (value) {
+            switch (value) {
+              case 'edit':
+                _showStudentDialog(student: student);
+                break;
+              case 'delete':
+                _confirmDelete(student);
+                break;
+            }
+          },
+          itemBuilder: (context) => [
+            const PopupMenuItem(
+              value: 'edit',
+              child: Row(
+                children: [
+                  Icon(Icons.edit_outlined),
+                  SizedBox(width: 8),
+                  Text('Bearbeiten'),
+                ],
+              ),
+            ),
+            const PopupMenuItem(
+              value: 'delete',
+              child: Row(
+                children: [
+                  Icon(Icons.delete_outlined, color: Colors.red),
+                  SizedBox(width: 8),
+                  Text('Löschen', style: TextStyle(color: Colors.red)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(String message) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.person_outline,
+            size: 64,
+            color: Colors.grey[400],
+          ),
+          const SizedBox(height: RBSSpacing.md),
+          Text(
+            message,
+            style: RBSTypography.h3.copyWith(color: Colors.grey[600]),
+          ),
+          if (_selectedKlasseId != null) ...[
+            const SizedBox(height: RBSSpacing.lg),
+            ElevatedButton.icon(
+              onPressed: () => _showStudentDialog(),
+              icon: const Icon(Icons.add),
+              label: const Text('Ersten Schüler hinzufügen'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: RBSColors.dynamicRed,
+                foregroundColor: Colors.white,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  void _showStudentDialog({Student? student}) {
+    final isEditing = student != null;
+    final pseudonymController = TextEditingController(
+      text: student?.pseudonym ?? '',
+    );
+
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(isEditing ? 'Schüler bearbeiten' : 'Neuer Schüler'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: pseudonymController,
+              decoration: const InputDecoration(
+                labelText: 'Pseudonym',
+                hintText: 'z.B. S001',
+                helperText: 'DSGVO-konform, kein echter Name',
+              ),
+              autofocus: true,
+            ),
+            const SizedBox(height: RBSSpacing.md),
+            Container(
+              padding: const EdgeInsets.all(RBSSpacing.sm),
+              decoration: BoxDecoration(
+                color: RBSColors.offwhite,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  Icon(Icons.info_outline, color: Colors.grey[600], size: 20),
+                  const SizedBox(width: RBSSpacing.sm),
+                  Expanded(
+                    child: Text(
+                      'Echte Namen werden nicht gespeichert (DSGVO)',
+                      style: RBSTypography.bodySmall.copyWith(
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Abbrechen'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              final pseudonym = pseudonymController.text.trim();
+              if (pseudonym.isEmpty) return;
+
+              final firestoreService = ref.read(firestoreServiceProvider);
+
+              try {
+                if (isEditing) {
+                  await firestoreService.updateStudent(
+                    student.copyWith(pseudonym: pseudonym),
+                  );
+                } else {
+                  await firestoreService.createStudent(
+                    Student(
+                      id: '',
+                      pseudonym: pseudonym,
+                      klasseId: _selectedKlasseId!,
+                      createdAt: DateTime.now(),
+                    ),
+                  );
+                }
+                if (context.mounted) Navigator.pop(context);
+              } catch (e) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Fehler: $e')),
+                  );
+                }
+              }
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: RBSColors.dynamicRed,
+              foregroundColor: Colors.white,
+            ),
+            child: Text(isEditing ? 'Speichern' : 'Hinzufügen'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmDelete(Student student) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Schüler löschen?'),
+        content: Text(
+          'Möchtest du "${student.displayName}" wirklich löschen?\n\n'
+          'Alle Noten dieses Schülers werden ebenfalls gelöscht.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Abbrechen'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              final firestoreService = ref.read(firestoreServiceProvider);
+              await firestoreService.deleteStudent(student.id);
+              if (context.mounted) Navigator.pop(context);
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Löschen'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _getBerufColor(Beruf? beruf) {
+    if (beruf == null) return RBSColors.dynamicRed;
+    switch (beruf) {
+      case Beruf.ie:
+        return RBSColors.dynamicRed;
+      case Beruf.eat:
+        return RBSColors.courtGreen;
+      case Beruf.ebt:
+        return RBSColors.growingElder;
+      case Beruf.egs:
+        return RBSColors.info; // Blau
+    }
+  }
+}

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -56,6 +56,26 @@ class FirestoreService {
     await batch.commit();
   }
 
+  /// Schüler nach Klasse abrufen
+  Stream<List<Student>> getStudentsByKlasse(String klasseId) {
+    return _students
+        .where('klasseId', isEqualTo: klasseId)
+        .orderBy('pseudonym')
+        .snapshots()
+        .map(
+          (snapshot) =>
+              snapshot.docs.map((doc) => Student.fromFirestore(doc)).toList(),
+        );
+  }
+
+  /// Nächstes verfügbares Pseudonym für eine Klasse
+  Future<String> getNextPseudonym(String klasseId) async {
+    final snapshot = await _students
+        .where('klasseId', isEqualTo: klasseId)
+        .get();
+    return Student.generatePseudonym(snapshot.docs.length);
+  }
+
   // ============ SUBJECTS ============
 
   Stream<List<Subject>> getSubjects() {
@@ -304,7 +324,7 @@ class FirestoreService {
         student
             .copyWith(
               id: studentId,
-              className: klasse.name,
+              klasseId: klasseId,
             )
             .toFirestore(),
       );

--- a/lib/widgets/rbs_drawer.dart
+++ b/lib/widgets/rbs_drawer.dart
@@ -64,7 +64,6 @@ class RBSDrawer extends ConsumerWidget {
                   icon: Icons.person_outline,
                   title: 'Schüler',
                   route: '/schueler',
-                  disabled: true,
                 ),
                 _buildDrawerItem(
                   context,


### PR DESCRIPTION
## Änderungen

### Neuer Screen: Schülerverwaltung
- Filter nach Klasse
- CRUD für Schüler (Hinzufügen, Bearbeiten, Löschen)
- DSGVO-konforme Pseudonymisierung (nur Pseudonyme in Firestore)

### Student Model erweitert
- \pseudonym\: Eindeutiger Bezeichner (z.B. S001, S002)
- \klasseId\: Referenz zur Klasse
- \irstName\/\lastName\: Optional, nur lokal
- \	oLocalMapping()\: Für CSV-Export des Mappings

### Neue Provider
- \studentsByKlasseProvider\: Schüler nach Klasse filtern

### Navigation
- Schüler-Link im Drawer aktiviert
- Route \/schueler\ hinzugefügt

### Fixes
- PDF-Import nutzt neues Student-Model mit Pseudonymen

## DSGVO
 Nur Pseudonyme werden in Firestore gespeichert
 Echte Namen optional/nur lokal
 Mapping kann exportiert werden

Closes #9